### PR TITLE
Filters

### DIFF
--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -38,9 +38,12 @@ class Analytics
         $this->requestData = new RequestData(propertyId: $propertyId);
     }
 
-    public static function query(): self
+    public static function query(): static
     {
-        return resolve(Analytics::class);
+        /** @var static $analytics */
+        $analytics = resolve(Analytics::class);
+
+        return $analytics;
     }
 
     /***************************************

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -9,6 +9,7 @@ use Google\ApiCore\ApiException;
 use Gtmassey\LaravelAnalytics\Exceptions\InvalidPropertyIdException;
 use Gtmassey\LaravelAnalytics\Reports\Reports;
 use Gtmassey\LaravelAnalytics\Request\Dimensions;
+use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
 use Gtmassey\LaravelAnalytics\Request\Metrics;
 use Gtmassey\LaravelAnalytics\Request\RequestData;
 use Gtmassey\LaravelAnalytics\Response\ResponseData;
@@ -70,6 +71,28 @@ class Analytics
         /** @var Dimensions $dimensions */
         $dimensions = $callback(resolve(Dimensions::class));
         $this->requestData->dimensions->push(...$dimensions->getDimensions());
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure(FilterExpression): FilterExpression  $callback
+     * @return static
+     */
+    public function dimensionFilter(Closure $callback): static
+    {
+        $this->requestData->dimensionFilter = $callback(new FilterExpression());
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure(FilterExpression): FilterExpression  $callback
+     * @return static
+     */
+    public function metricFilter(Closure $callback): static
+    {
+        $this->requestData->metricFilter = $callback(new FilterExpression());
 
         return $this;
     }

--- a/src/Exceptions/InvalidFilterException.php
+++ b/src/Exceptions/InvalidFilterException.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Exceptions;
+
+use Exception;
+
+class InvalidFilterException extends Exception
+{
+    const NO_DIMENSION_FILTER = 'No dimension filter was set.';
+
+    const NO_METRIC_FILTER = 'No metric filter was set.';
+
+    public static function noDimensionFilter(): self
+    {
+        return new self(message: self::NO_DIMENSION_FILTER);
+    }
+
+    public static function noMetricFilter(): self
+    {
+        return new self(message: self::NO_METRIC_FILTER);
+    }
+}

--- a/src/Request/Dimensions.php
+++ b/src/Request/Dimensions.php
@@ -20,6 +20,11 @@ class Dimensions
         return $this->dimensions->count();
     }
 
+    public function first(): ?Dimension
+    {
+        return $this->dimensions->first();
+    }
+
     /**
      * @return Collection<int, Dimension>
      */

--- a/src/Request/Filters/AndGroup.php
+++ b/src/Request/Filters/AndGroup.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Closure;
+use Google\Analytics\Data\V1beta\FilterExpressionList as BaseFilterExpressionList;
+
+class AndGroup implements FilterExpressionContract
+{
+    private FilterExpressionList $expression;
+
+    /**
+     * @param  Closure(FilterExpressionList): FilterExpressionList  $expression
+     * @param  FilterExpressionField  $field
+     */
+    public function __construct(
+        Closure $expression,
+        private readonly FilterExpressionField $field = FilterExpressionField::AND_GROUP,
+    ) {
+        $this->expression = $expression(new FilterExpressionList());
+    }
+
+    public function toRequest(): BaseFilterExpressionList
+    {
+        return $this->expression->toRequest();
+    }
+
+    public function field(): FilterExpressionField
+    {
+        return $this->field;
+    }
+}

--- a/src/Request/Filters/BetweenFilter.php
+++ b/src/Request/Filters/BetweenFilter.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Google\Analytics\Data\V1beta\Filter\BetweenFilter as BaseBetweenFilter;
+use Google\Analytics\Data\V1beta\NumericValue;
+
+class BetweenFilter implements FilterContract
+{
+    public function __construct(
+        private readonly float|int $min = 0,
+        private readonly float|int $max = 0,
+        private readonly NumericValueType $valueType = NumericValueType::INTEGER,
+        private readonly FilterField $field = FilterField::BETWEEN_FILTER,
+    ) {
+    }
+
+    public function toRequest(): BaseBetweenFilter
+    {
+        return new BaseBetweenFilter([
+            'from_value' => new NumericValue([
+                $this->valueType->value => $this->min,
+            ]),
+            'to_value' => new NumericValue([
+                $this->valueType->value => $this->max,
+            ]),
+        ]);
+    }
+
+    public function field(): FilterField
+    {
+        return $this->field;
+    }
+}

--- a/src/Request/Filters/Filter.php
+++ b/src/Request/Filters/Filter.php
@@ -1,0 +1,242 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Google\Analytics\Data\V1beta\Filter as BaseFilter;
+use Google\Analytics\Data\V1beta\Filter\NumericFilter\Operation;
+use Google\Analytics\Data\V1beta\Filter\StringFilter\MatchType;
+
+class Filter implements FilterExpressionContract
+{
+    public ?string $fieldName = null;
+
+    public ?FilterContract $expression = null;
+
+    public function __construct(
+        string $fieldName,
+        private readonly FilterExpressionField $field = FilterExpressionField::FILTER,
+    ) {
+        $this->fieldName = $fieldName;
+    }
+
+    public function exact(string $value, bool $caseSensitive = false): static
+    {
+        $this->expression = new StringFilter(
+            matchType: MatchType::EXACT,
+            value: $value,
+            caseSensitive: $caseSensitive,
+        );
+
+        return $this;
+    }
+
+    public function beginsWith(string $value, bool $caseSensitive = false): static
+    {
+        $this->expression = new StringFilter(
+            matchType: MatchType::BEGINS_WITH,
+            value: $value,
+            caseSensitive: $caseSensitive,
+        );
+
+        return $this;
+    }
+
+    public function endsWith(string $value, bool $caseSensitive = false): static
+    {
+        $this->expression = new StringFilter(
+            matchType: MatchType::ENDS_WITH,
+            value: $value,
+            caseSensitive: $caseSensitive,
+        );
+
+        return $this;
+    }
+
+    public function contains(string $value, bool $caseSensitive = false): static
+    {
+        $this->expression = new StringFilter(
+            matchType: MatchType::CONTAINS,
+            value: $value,
+            caseSensitive: $caseSensitive,
+        );
+
+        return $this;
+    }
+
+    public function fullRegexp(string $value, bool $caseSensitive = false): static
+    {
+        $this->expression = new StringFilter(
+            matchType: MatchType::FULL_REGEXP,
+            value: $value,
+            caseSensitive: $caseSensitive,
+        );
+
+        return $this;
+    }
+
+    public function partialRegexp(string $value, bool $caseSensitive = false): static
+    {
+        $this->expression = new StringFilter(
+            matchType: MatchType::PARTIAL_REGEXP,
+            value: $value,
+            caseSensitive: $caseSensitive,
+        );
+
+        return $this;
+    }
+
+    public function inList(array $values, bool $caseSensitive = false): static
+    {
+        $this->expression = new InListFilter(
+            values: $values,
+            caseSensitive: $caseSensitive,
+        );
+
+        return $this;
+    }
+
+    public function equalInt(int $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::EQUAL,
+            value: $value,
+            valueType: NumericValueType::INTEGER,
+        );
+
+        return $this;
+    }
+
+    public function equalFloat(float $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::EQUAL,
+            value: $value,
+            valueType: NumericValueType::FLOAT,
+        );
+
+        return $this;
+    }
+
+    public function lessThanInt(int $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::LESS_THAN,
+            value: $value,
+            valueType: NumericValueType::INTEGER,
+        );
+
+        return $this;
+    }
+
+    public function lessThanFloat(float $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::LESS_THAN,
+            value: $value,
+            valueType: NumericValueType::FLOAT,
+        );
+
+        return $this;
+    }
+
+    public function lessThanOrEqualInt(int $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::LESS_THAN_OR_EQUAL,
+            value: $value,
+            valueType: NumericValueType::INTEGER,
+        );
+
+        return $this;
+    }
+
+    public function lessThanOrEqualFloat(float $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::LESS_THAN_OR_EQUAL,
+            value: $value,
+            valueType: NumericValueType::FLOAT,
+        );
+
+        return $this;
+    }
+
+    public function greaterThanInt(int $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::GREATER_THAN,
+            value: $value,
+            valueType: NumericValueType::INTEGER,
+        );
+
+        return $this;
+    }
+
+    public function greaterThanFloat(float $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::GREATER_THAN,
+            value: $value,
+            valueType: NumericValueType::FLOAT,
+        );
+
+        return $this;
+    }
+
+    public function greaterThanOrEqualInt(int $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::GREATER_THAN_OR_EQUAL,
+            value: $value,
+            valueType: NumericValueType::INTEGER,
+        );
+
+        return $this;
+    }
+
+    public function greaterThanOrEqualFloat(float $value): static
+    {
+        $this->expression = new NumericFilter(
+            operation: Operation::GREATER_THAN_OR_EQUAL,
+            value: $value,
+            valueType: NumericValueType::FLOAT,
+        );
+
+        return $this;
+    }
+
+    public function betweenInt(int $min, int $max): static
+    {
+        $this->expression = new BetweenFilter(
+            min: $min,
+            max: $max,
+            valueType: NumericValueType::INTEGER,
+        );
+
+        return $this;
+    }
+
+    public function betweenFloat(float $min, float $max): static
+    {
+        $this->expression = new BetweenFilter(
+            min: $min,
+            max: $max,
+            valueType: NumericValueType::FLOAT,
+        );
+
+        return $this;
+    }
+
+    public function toRequest(): BaseFilter
+    {
+        return new BaseFilter([
+            'field_name' => $this->fieldName,
+            $this->expression?->field()->value => $this->expression?->toRequest(),
+        ]);
+    }
+
+    public function field(): FilterExpressionField
+    {
+        return $this->field;
+    }
+}

--- a/src/Request/Filters/FilterContract.php
+++ b/src/Request/Filters/FilterContract.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Google\Analytics\Data\V1beta\Filter\BetweenFilter as BaseBetweenFilter;
+use Google\Analytics\Data\V1beta\Filter\InListFilter as BaseInListFilter;
+use Google\Analytics\Data\V1beta\Filter\NumericFilter as BaseNumericFilter;
+use Google\Analytics\Data\V1beta\Filter\StringFilter as BaseStringFilter;
+
+interface FilterContract
+{
+    public function field(): FilterField;
+
+    public function toRequest(): BaseStringFilter|BaseInListFilter|BaseNumericFilter|BaseBetweenFilter;
+}

--- a/src/Request/Filters/FilterExpression.php
+++ b/src/Request/Filters/FilterExpression.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Closure;
+use Google\Analytics\Data\V1beta\FilterExpression as BaseFilterExpression;
+use Gtmassey\LaravelAnalytics\Exceptions\InvalidFilterException;
+use Gtmassey\LaravelAnalytics\Request\Dimensions;
+use Gtmassey\LaravelAnalytics\Request\Metrics;
+
+class FilterExpression
+{
+    private FilterExpressionContract $expression;
+
+    /**
+     * @param  Closure(FilterExpressionList): FilterExpressionList  $filterExpressionList
+     * @return static
+     */
+    public function andGroup(Closure $filterExpressionList): static
+    {
+        $this->expression = new AndGroup($filterExpressionList);
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure(FilterExpressionList): FilterExpressionList  $filterExpressionList
+     * @return static
+     */
+    public function orGroup(Closure $filterExpressionList): static
+    {
+        $this->expression = new OrGroup($filterExpressionList);
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure(FilterExpression): FilterExpression  $filterExpression
+     * @return static
+     */
+    public function not(Closure $filterExpression): static
+    {
+        $this->expression = new NotExpression($filterExpression);
+
+        return $this;
+    }
+
+    /**
+     * @param  string  $dimension
+     * @param  Closure(Filter): Filter  $filter
+     * @return static
+     */
+    public function filter(string $dimension, Closure $filter): static
+    {
+        $this->expression = $filter(new Filter($dimension));
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure  $dimensionsCallback
+     * @param  Closure(Filter): Filter  $filter
+     * @return static
+     *
+     * @throws InvalidFilterException
+     */
+    public function filterDimension(Closure $dimensionsCallback, Closure $filter): static
+    {
+        /** @var Dimensions $dimensions */
+        $dimensions = $dimensionsCallback(resolve(Dimensions::class));
+
+        $firstDimension = $dimensions->first();
+
+        if ($firstDimension === null) {
+            throw InvalidFilterException::noDimensionFilter();
+        }
+
+        return $this->filter($firstDimension->getName(), $filter);
+    }
+
+    /**
+     * @param  Closure  $metricsCallback
+     * @param  Closure(Filter): Filter  $filter
+     * @return static
+     *
+     * @throws InvalidFilterException
+     */
+    public function filterMetric(Closure $metricsCallback, Closure $filter): static
+    {
+        /** @var Metrics $metrics */
+        $metrics = $metricsCallback(resolve(Metrics::class));
+
+        $firstMetric = $metrics->first();
+
+        if ($firstMetric === null) {
+            throw InvalidFilterException::noMetricFilter();
+        }
+
+        return $this->filter($firstMetric->getName(), $filter);
+    }
+
+    public function toRequest(): BaseFilterExpression
+    {
+        return new BaseFilterExpression([
+            $this->expression->field()->value => $this->expression->toRequest(),
+        ]);
+    }
+}

--- a/src/Request/Filters/FilterExpressionContract.php
+++ b/src/Request/Filters/FilterExpressionContract.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Google\Analytics\Data\V1beta\Filter as BaseFilter;
+use Google\Analytics\Data\V1beta\FilterExpression as BaseFilterExpression;
+use Google\Analytics\Data\V1beta\FilterExpressionList as BaseFilterExpressionList;
+
+interface FilterExpressionContract
+{
+    public function field(): FilterExpressionField;
+
+    public function toRequest(): BaseFilter|BaseFilterExpression|BaseFilterExpressionList;
+}

--- a/src/Request/Filters/FilterExpressionField.php
+++ b/src/Request/Filters/FilterExpressionField.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+enum FilterExpressionField: string
+{
+    case AND_GROUP = 'and_group';
+    case OR_GROUP = 'or_group';
+    case NOT_EXPRESSION = 'not_expression';
+    case FILTER = 'filter';
+}

--- a/src/Request/Filters/FilterExpressionList.php
+++ b/src/Request/Filters/FilterExpressionList.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Closure;
+use Google\Analytics\Data\V1beta\FilterExpressionList as BaseFilterExpressionList;
+use Gtmassey\LaravelAnalytics\Exceptions\InvalidFilterException;
+use Illuminate\Support\Collection;
+
+class FilterExpressionList
+{
+    public function __construct(
+        /** @var Collection<int, FilterExpression> */
+        private readonly Collection $expressions = new Collection(),
+    ) {
+    }
+
+    /**
+     * @param  Closure(FilterExpressionList): FilterExpressionList  $filterExpressionList
+     * @return static
+     */
+    public function andGroup(Closure $filterExpressionList): static
+    {
+        $this->expressions->push((new FilterExpression())->andGroup($filterExpressionList));
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure(FilterExpressionList): FilterExpressionList  $filterExpressionList
+     * @return static
+     */
+    public function orGroup(Closure $filterExpressionList): static
+    {
+        $this->expressions->push((new FilterExpression())->orGroup($filterExpressionList));
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure(FilterExpression): FilterExpression  $filterExpression
+     * @return static
+     */
+    public function not(Closure $filterExpression): static
+    {
+        $this->expressions->push((new FilterExpression())->not($filterExpression));
+
+        return $this;
+    }
+
+    /**
+     * @param  string  $dimension
+     * @param  Closure(Filter): Filter  $filter
+     * @return static
+     */
+    public function filter(string $dimension, Closure $filter): static
+    {
+        $this->expressions->push((new FilterExpression())->filter($dimension, $filter));
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure  $dimensionsCallback
+     * @param  Closure(Filter): Filter  $filter
+     * @return static
+     *
+     * @throws InvalidFilterException
+     */
+    public function filterDimension(Closure $dimensionsCallback, Closure $filter): static
+    {
+        $this->expressions->push((new FilterExpression())->filterDimension($dimensionsCallback, $filter));
+
+        return $this;
+    }
+
+    /**
+     * @param  Closure  $metricsCallback
+     * @param  Closure(Filter): Filter  $filter
+     * @return static
+     *
+     * @throws InvalidFilterException
+     */
+    public function filterMetric(Closure $metricsCallback, Closure $filter): static
+    {
+        $this->expressions->push((new FilterExpression())->filterMetric($metricsCallback, $filter));
+
+        return $this;
+    }
+
+    public function toRequest(): BaseFilterExpressionList
+    {
+        return new BaseFilterExpressionList([
+            'expressions' => $this->expressions
+                ->map(fn (FilterExpression $filterExpression) => $filterExpression->toRequest())
+                ->toArray(),
+        ]);
+    }
+}

--- a/src/Request/Filters/FilterField.php
+++ b/src/Request/Filters/FilterField.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+enum FilterField: string
+{
+    case STRING_FILTER = 'string_filter';
+    case IN_LIST_FILTER = 'in_list_filter';
+    case NUMERIC_FILTER = 'numeric_filter';
+    case BETWEEN_FILTER = 'between_filter';
+}

--- a/src/Request/Filters/InListFilter.php
+++ b/src/Request/Filters/InListFilter.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Google\Analytics\Data\V1beta\Filter\InListFilter as BaseInListFilter;
+
+class InListFilter implements FilterContract
+{
+    public function __construct(
+        public array $values = [],
+        public bool $caseSensitive = false,
+        private readonly FilterField $field = FilterField::IN_LIST_FILTER,
+    ) {
+    }
+
+    public function field(): FilterField
+    {
+        return $this->field;
+    }
+
+    public function toRequest(): BaseInListFilter
+    {
+        return new BaseInListFilter([
+            'values' => $this->values,
+            'case_sensitive' => $this->caseSensitive,
+        ]);
+    }
+}

--- a/src/Request/Filters/NotExpression.php
+++ b/src/Request/Filters/NotExpression.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Closure;
+use Google\Analytics\Data\V1beta\FilterExpression as BaseFilterExpression;
+
+class NotExpression implements FilterExpressionContract
+{
+    private FilterExpression $expression;
+
+    /**
+     * @param  Closure(FilterExpression): FilterExpression  $expression
+     * @param  FilterExpressionField  $field
+     */
+    public function __construct(
+        Closure $expression,
+        private readonly FilterExpressionField $field = FilterExpressionField::NOT_EXPRESSION,
+    ) {
+        $this->expression = $expression(new FilterExpression());
+    }
+
+    public function toRequest(): BaseFilterExpression
+    {
+        return $this->expression->toRequest();
+    }
+
+    public function field(): FilterExpressionField
+    {
+        return $this->field;
+    }
+}

--- a/src/Request/Filters/NumericFilter.php
+++ b/src/Request/Filters/NumericFilter.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Google\Analytics\Data\V1beta\Filter\NumericFilter as BaseNumericFilter;
+use Google\Analytics\Data\V1beta\Filter\NumericFilter\Operation;
+use Google\Analytics\Data\V1beta\NumericValue;
+
+class NumericFilter implements FilterContract
+{
+    public function __construct(
+        private readonly int $operation = Operation::OPERATION_UNSPECIFIED,
+        private readonly float|int $value = 0,
+        private readonly NumericValueType $valueType = NumericValueType::INTEGER,
+        private readonly FilterField $field = FilterField::NUMERIC_FILTER,
+    ) {
+    }
+
+    public function toRequest(): BaseNumericFilter
+    {
+        return new BaseNumericFilter([
+            'operation' => $this->operation,
+            'value' => new NumericValue([
+                $this->valueType->value => $this->value,
+            ]),
+        ]);
+    }
+
+    public function field(): FilterField
+    {
+        return $this->field;
+    }
+}

--- a/src/Request/Filters/NumericValueType.php
+++ b/src/Request/Filters/NumericValueType.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+enum NumericValueType: string
+{
+    case INTEGER = 'int64_value';
+    case FLOAT = 'double_value';
+}

--- a/src/Request/Filters/OrGroup.php
+++ b/src/Request/Filters/OrGroup.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Closure;
+use Google\Analytics\Data\V1beta\FilterExpressionList as BaseFilterExpressionList;
+
+class OrGroup implements FilterExpressionContract
+{
+    private FilterExpressionList $expression;
+
+    /**
+     * @param  Closure(FilterExpressionList): FilterExpressionList  $expression
+     * @param  FilterExpressionField  $field
+     */
+    public function __construct(
+        Closure $expression,
+        private readonly FilterExpressionField $field = FilterExpressionField::OR_GROUP,
+    ) {
+        $this->expression = $expression(new FilterExpressionList());
+    }
+
+    public function toRequest(): BaseFilterExpressionList
+    {
+        return $this->expression->toRequest();
+    }
+
+    public function field(): FilterExpressionField
+    {
+        return $this->field;
+    }
+}

--- a/src/Request/Filters/StringFilter.php
+++ b/src/Request/Filters/StringFilter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Request\Filters;
+
+use Google\Analytics\Data\V1beta\Filter\StringFilter as BaseStringFilter;
+use Google\Analytics\Data\V1beta\Filter\StringFilter\MatchType;
+
+class StringFilter implements FilterContract
+{
+    public function __construct(
+        private readonly int $matchType = MatchType::MATCH_TYPE_UNSPECIFIED,
+        private readonly string $value = '',
+        private readonly bool $caseSensitive = false,
+        private readonly FilterField $field = FilterField::STRING_FILTER,
+    ) {
+    }
+
+    public function toRequest(): BaseStringFilter
+    {
+        return new BaseStringFilter([
+            'match_type' => $this->matchType,
+            'value' => $this->value,
+            'case_sensitive' => $this->caseSensitive,
+        ]);
+    }
+
+    public function field(): FilterField
+    {
+        return $this->field;
+    }
+}

--- a/src/Request/Metrics.php
+++ b/src/Request/Metrics.php
@@ -20,6 +20,11 @@ class Metrics
         return $this->metrics->count();
     }
 
+    public function first(): ?Metric
+    {
+        return $this->metrics->first();
+    }
+
     /**
      * @return Collection<int, Metric>
      */

--- a/src/Request/RequestData.php
+++ b/src/Request/RequestData.php
@@ -4,8 +4,10 @@ namespace Gtmassey\LaravelAnalytics\Request;
 
 use Google\Analytics\Data\V1beta\DateRange;
 use Google\Analytics\Data\V1beta\Dimension;
+use Google\Analytics\Data\V1beta\FilterExpression as BaseFilterExpression;
 use Google\Analytics\Data\V1beta\Metric;
 use Google\Analytics\Data\V1beta\MetricAggregation;
+use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
 use Illuminate\Support\Collection;
 use Spatie\LaravelData\Data;
 
@@ -26,13 +28,17 @@ class RequestData extends Data
         /** @var Collection<int, Dimension> */
         public Collection $dimensions = new Collection(),
 
+        public ?FilterExpression $dimensionFilter = null,
+
+        public ?FilterExpression $metricFilter = null,
+
         public bool $returnPropertyQuota = true,
 
         public bool $useTotals = false,
     ) {
     }
 
-    /** @return array{property: string, dateRanges: DateRange[], dimensions: Dimension[], metrics: Metric[], returnPropertyQuota: bool, metricAggregations: int[]} */
+    /** @return array{property: string, dateRanges: DateRange[], dimensions: Dimension[], metrics: Metric[], dimensionFilter: BaseFilterExpression|null, returnPropertyQuota: bool, metricAggregations: int[]} */
     public function toArray(): array
     {
         return [
@@ -40,6 +46,8 @@ class RequestData extends Data
             'dateRanges' => $this->dateRanges->all(),
             'dimensions' => $this->dimensions->unique()->all(),
             'metrics' => $this->metrics->unique()->all(),
+            'dimensionFilter' => $this->dimensionFilter?->toRequest(),
+            'metricFilter' => $this->metricFilter?->toRequest(),
             'returnPropertyQuota' => $this->returnPropertyQuota,
             'metricAggregations' => $this->useTotals ? [MetricAggregation::TOTAL] : [],
         ];

--- a/src/Response/ResponseData.php
+++ b/src/Response/ResponseData.php
@@ -41,6 +41,6 @@ class ResponseData extends Data
 
         $report = json_decode($json, true);
 
-        return self::from($report);
+        return self::from($report + ['rows' => new DataCollection(Row::class, []), 'rowCount' => 0]);
     }
 }

--- a/tests/DimensionsTest.php
+++ b/tests/DimensionsTest.php
@@ -916,6 +916,7 @@ class DimensionsTest extends TestCase
     /**
      * @param  Closure(Dimensions): Dimensions  $method
      * @param  string  $dimension
+     *
      * @dataProvider dimensionProvider
      */
     public function test_predefined_dimensions(Closure $method, string $dimension): void

--- a/tests/FiltersTest.php
+++ b/tests/FiltersTest.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Gtmassey\LaravelAnalytics\Tests;
+
+use Gtmassey\LaravelAnalytics\Analytics;
+use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
+use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
+use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpressionList;
+use Gtmassey\LaravelAnalytics\Request\RequestData;
+use ReflectionProperty;
+
+class FiltersTest extends TestCase
+{
+    public function testFilters(): void
+    {
+		$this->markTestSkipped();
+        $analytics = Analytics::query()
+//			->dimensionFilter(fn(FilterExpression $filterExpression) => $filterExpression
+//				->not(fn(FilterExpression $filterExpression) => $filterExpression
+//					->filter('browser', fn(Filter $filter) => $filter
+//						->contains('safari')
+//					)
+//				)
+//			)
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->andGroup(fn (FilterExpressionList $filterExpressionList) => $filterExpressionList
+                    ->filter()
+                )
+                ->not(fn (FilterExpression $filterExpression) => $filterExpression
+                    ->filter('browser', fn (Filter $filter) => $filter
+                        ->contains('safari')
+                    )
+                )
+            );
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        dd(json_decode($requestData->dimensionFilter?->toRequest()->serializeToJsonString()));
+
+        //			->setFilters(function (FilterExpression $filterExpression) {
+        //				return $filterExpression->orGroup(fn(OrGroup $orGroup) => $orGroup
+        //					->addFilter(fn(FilterExpression $filterExpression) => $filterExpression
+        //						->not(fn(FilterExpression $filterExpression) => $filterExpression
+        //							->filter($dimension, fn(Filter $filter) => $filter
+        //								->contains('Chrome')
+        //							)
+        //						)
+        //					)
+        //					->addFilter(fn(FilterExpression $filterExpression) => $filterExpression
+        //						->filter($dimension)->contains('Chrome')
+        //					)
+        //				);
+        //			})
+
+        //			->run();
+    }
+}

--- a/tests/FiltersTest.php
+++ b/tests/FiltersTest.php
@@ -3,55 +3,1089 @@
 namespace Gtmassey\LaravelAnalytics\Tests;
 
 use Gtmassey\LaravelAnalytics\Analytics;
+use Gtmassey\LaravelAnalytics\Exceptions\InvalidFilterException;
+use Gtmassey\LaravelAnalytics\Request\Dimensions;
 use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
 use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
 use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpressionList;
+use Gtmassey\LaravelAnalytics\Request\Metrics;
 use Gtmassey\LaravelAnalytics\Request\RequestData;
 use ReflectionProperty;
 
 class FiltersTest extends TestCase
 {
-    public function testFilters(): void
+    public function test_filter_dimension_string_exact(): void
     {
-		$this->markTestSkipped();
         $analytics = Analytics::query()
-//			->dimensionFilter(fn(FilterExpression $filterExpression) => $filterExpression
-//				->not(fn(FilterExpression $filterExpression) => $filterExpression
-//					->filter('browser', fn(Filter $filter) => $filter
-//						->contains('safari')
-//					)
-//				)
-//			)
             ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
-                ->andGroup(fn (FilterExpressionList $filterExpressionList) => $filterExpressionList
-                    ->filter()
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->exact('Chrome')
                 )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'EXACT',
+                    'value' => 'Chrome',
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_exact_case_sensitive(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->exact('Chrome', true)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'EXACT',
+                    'value' => 'Chrome',
+                    'caseSensitive' => true,
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_begins_with(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->beginsWith('Safari')
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'BEGINS_WITH',
+                    'value' => 'Safari',
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_begins_with_case_sensitive(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->beginsWith('Safari', true)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'BEGINS_WITH',
+                    'value' => 'Safari',
+                    'caseSensitive' => true,
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_ends_with(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->endsWith('fox')
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'ENDS_WITH',
+                    'value' => 'fox',
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_ends_with_case_sensitive(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->endsWith('fox', true)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'ENDS_WITH',
+                    'value' => 'fox',
+                    'caseSensitive' => true,
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_contains(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->contains('fox')
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'CONTAINS',
+                    'value' => 'fox',
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_contains_case_sensitive(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->contains('fox', true)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'CONTAINS',
+                    'value' => 'fox',
+                    'caseSensitive' => true,
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_full_regexp(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->fullRegexp('/Firefox/')
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'FULL_REGEXP',
+                    'value' => '/Firefox/',
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_full_regexp_case_sensitive(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->fullRegexp('/Firefox/', true)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'FULL_REGEXP',
+                    'value' => '/Firefox/',
+                    'caseSensitive' => true,
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_partial_regexp(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->partialRegexp('/fox/')
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'PARTIAL_REGEXP',
+                    'value' => '/fox/',
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_partial_regexp_case_sensitive(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->partialRegexp('/fox/', true)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'PARTIAL_REGEXP',
+                    'value' => '/fox/',
+                    'caseSensitive' => true,
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_in_list(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->inList(['Firefox', 'Chrome'])
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'inListFilter' => [
+                    'values' => ['Firefox', 'Chrome'],
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_dimension_string_in_list_case_sensitive(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('browser', fn (Filter $filter) => $filter
+                    ->inList(['Firefox', 'Chrome'], true)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'inListFilter' => [
+                    'values' => ['Firefox', 'Chrome'],
+                    'caseSensitive' => true,
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    /**
+     * @throws InvalidFilterException
+     */
+    public function test_filter_dimension_object_string_exact(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filterDimension(
+                    dimensionsCallback: fn (Dimensions $dimensions) => $dimensions->browser(),
+                    filter: fn (Filter $filter) => $filter->exact('Chrome')
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'browser',
+                'stringFilter' => [
+                    'matchType' => 'EXACT',
+                    'value' => 'Chrome',
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_invalid_dimension_filter(): void
+    {
+        $this->expectException(InvalidFilterException::class);
+        $this->expectExceptionMessage(InvalidFilterException::NO_DIMENSION_FILTER);
+
+        Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filterDimension(
+                    dimensionsCallback: fn (Dimensions $dimensions) => $dimensions,
+                    filter: fn (Filter $filter) => $filter->exact('Chrome')
+                )
+            );
+    }
+
+    public function test_filter_metric_equal_int(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('sessions', fn (Filter $filter) => $filter
+                    ->equalInt(100)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'sessions',
+                'numericFilter' => [
+                    'operation' => 'EQUAL',
+                    'value' => [
+                        'int64Value' => '100',
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_equal_float(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('eventsPerSession', fn (Filter $filter) => $filter
+                    ->equalFloat(1.23)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'eventsPerSession',
+                'numericFilter' => [
+                    'operation' => 'EQUAL',
+                    'value' => [
+                        'doubleValue' => 1.23,
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_less_than_int(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('sessions', fn (Filter $filter) => $filter
+                    ->lessThanInt(100)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'sessions',
+                'numericFilter' => [
+                    'operation' => 'LESS_THAN',
+                    'value' => [
+                        'int64Value' => '100',
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_less_than_float(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('eventsPerSession', fn (Filter $filter) => $filter
+                    ->lessThanFloat(1.23)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'eventsPerSession',
+                'numericFilter' => [
+                    'operation' => 'LESS_THAN',
+                    'value' => [
+                        'doubleValue' => 1.23,
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_less_than_or_equal_int(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('sessions', fn (Filter $filter) => $filter
+                    ->lessThanOrEqualInt(100)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'sessions',
+                'numericFilter' => [
+                    'operation' => 'LESS_THAN_OR_EQUAL',
+                    'value' => [
+                        'int64Value' => '100',
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_less_than_or_equal_float(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('eventsPerSession', fn (Filter $filter) => $filter
+                    ->lessThanOrEqualFloat(1.23)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'eventsPerSession',
+                'numericFilter' => [
+                    'operation' => 'LESS_THAN_OR_EQUAL',
+                    'value' => [
+                        'doubleValue' => 1.23,
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_greater_than_int(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('sessions', fn (Filter $filter) => $filter
+                    ->greaterThanInt(100)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'sessions',
+                'numericFilter' => [
+                    'operation' => 'GREATER_THAN',
+                    'value' => [
+                        'int64Value' => '100',
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_greater_than_float(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('eventsPerSession', fn (Filter $filter) => $filter
+                    ->greaterThanFloat(1.23)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'eventsPerSession',
+                'numericFilter' => [
+                    'operation' => 'GREATER_THAN',
+                    'value' => [
+                        'doubleValue' => 1.23,
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_greater_than_or_equal_int(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('sessions', fn (Filter $filter) => $filter
+                    ->greaterThanOrEqualInt(100)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'sessions',
+                'numericFilter' => [
+                    'operation' => 'GREATER_THAN_OR_EQUAL',
+                    'value' => [
+                        'int64Value' => '100',
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_greater_than_or_equal_float(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('eventsPerSession', fn (Filter $filter) => $filter
+                    ->greaterThanOrEqualFloat(1.23)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'eventsPerSession',
+                'numericFilter' => [
+                    'operation' => 'GREATER_THAN_OR_EQUAL',
+                    'value' => [
+                        'doubleValue' => 1.23,
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_between_int(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('sessions', fn (Filter $filter) => $filter
+                    ->betweenInt(100, 200)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'sessions',
+                'betweenFilter' => [
+                    'fromValue' => [
+                        'int64Value' => '100',
+                    ],
+                    'toValue' => [
+                        'int64Value' => '200',
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_filter_metric_between_float(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filter('eventsPerSession', fn (Filter $filter) => $filter
+                    ->betweenFloat(1.23, 2.34)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'eventsPerSession',
+                'betweenFilter' => [
+                    'fromValue' => [
+                        'doubleValue' => 1.23,
+                    ],
+                    'toValue' => [
+                        'doubleValue' => 2.34,
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    /**
+     * @throws InvalidFilterException
+     */
+    public function test_filter_metric_object_equal_int(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filterMetric(
+                    metricsCallback: fn (Metrics $metrics) => $metrics->sessions(),
+                    filter: fn (Filter $filter) => $filter->equalInt(100)
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'filter' => [
+                'fieldName' => 'sessions',
+                'numericFilter' => [
+                    'operation' => 'EQUAL',
+                    'value' => [
+                        'int64Value' => '100',
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    public function test_invalid_metric_filter(): void
+    {
+        $this->expectException(InvalidFilterException::class);
+        $this->expectExceptionMessage(InvalidFilterException::NO_METRIC_FILTER);
+
+        Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->filterMetric(
+                    metricsCallback: fn (Metrics $metrics) => $metrics,
+                    filter: fn (Filter $filter) => $filter->equalInt(100)
+                )
+            );
+    }
+
+    public function test_filter_not_expression(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
                 ->not(fn (FilterExpression $filterExpression) => $filterExpression
                     ->filter('browser', fn (Filter $filter) => $filter
-                        ->contains('safari')
+                        ->exact('Chrome')
                     )
                 )
             );
 
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
         /** @var RequestData $requestData */
         $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
-        dd(json_decode($requestData->dimensionFilter?->toRequest()->serializeToJsonString()));
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
 
-        //			->setFilters(function (FilterExpression $filterExpression) {
-        //				return $filterExpression->orGroup(fn(OrGroup $orGroup) => $orGroup
-        //					->addFilter(fn(FilterExpression $filterExpression) => $filterExpression
-        //						->not(fn(FilterExpression $filterExpression) => $filterExpression
-        //							->filter($dimension, fn(Filter $filter) => $filter
-        //								->contains('Chrome')
-        //							)
-        //						)
-        //					)
-        //					->addFilter(fn(FilterExpression $filterExpression) => $filterExpression
-        //						->filter($dimension)->contains('Chrome')
-        //					)
-        //				);
-        //			})
+        $this->assertNotNull($dimensionFilter);
 
-        //			->run();
+        $this->assertEquals([
+            'notExpression' => [
+                'filter' => [
+                    'fieldName' => 'browser',
+                    'stringFilter' => [
+                        'matchType' => 'EXACT',
+                        'value' => 'Chrome',
+                    ],
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    /**
+     * @throws InvalidFilterException
+     */
+    public function test_filter_and_group_expression_list(): void
+    {
+        $analytics = Analytics::query()
+            ->metricFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->andGroup(fn (FilterExpressionList $filterExpressionList) => $filterExpressionList
+                    ->filter('sessions', fn (Filter $filter) => $filter
+                        ->greaterThanInt(100)
+                    )
+                    ->filterMetric(
+                        metricsCallback: fn (Metrics $metrics) => $metrics->totalUsers(),
+                        filter: fn (Filter $filter) => $filter->lessThanInt(100)
+                    )
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $metricFilter = $requestData->metricFilter?->toRequest();
+
+        $this->assertNotNull($metricFilter);
+
+        $this->assertEquals([
+            'andGroup' => [
+                'expressions' => [
+                    [
+                        'filter' => [
+                            'fieldName' => 'sessions',
+                            'numericFilter' => [
+                                'operation' => 'GREATER_THAN',
+                                'value' => [
+                                    'int64Value' => '100',
+                                ],
+                            ],
+                        ],
+                    ],
+                    [
+                        'filter' => [
+                            'fieldName' => 'totalUsers',
+                            'numericFilter' => [
+                                'operation' => 'LESS_THAN',
+                                'value' => [
+                                    'int64Value' => '100',
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], json_decode($metricFilter->serializeToJsonString(), true));
+    }
+
+    /**
+     * @throws InvalidFilterException
+     */
+    public function test_filter_or_group_expression_list(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->orGroup(fn (FilterExpressionList $filterExpressionList) => $filterExpressionList
+                    ->filter('browser', fn (Filter $filter) => $filter
+                        ->exact('Chrome')
+                    )
+                    ->filterDimension(
+                        dimensionsCallback: fn (Dimensions $dimensions) => $dimensions->deviceCategory(),
+                        filter: fn (Filter $filter) => $filter->exact('Mobile')
+                    )
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'orGroup' => [
+                'expressions' => [
+                    [
+                        'filter' => [
+                            'fieldName' => 'browser',
+                            'stringFilter' => [
+                                'matchType' => 'EXACT',
+                                'value' => 'Chrome',
+                            ],
+                        ],
+                    ],
+                    [
+                        'filter' => [
+                            'fieldName' => 'deviceCategory',
+                            'stringFilter' => [
+                                'matchType' => 'EXACT',
+                                'value' => 'Mobile',
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
+    }
+
+    public function test_nested_filters(): void
+    {
+        $analytics = Analytics::query()
+            ->dimensionFilter(fn (FilterExpression $filterExpression) => $filterExpression
+                ->orGroup(fn (FilterExpressionList $filterExpressionList) => $filterExpressionList
+                    ->andGroup(fn (FilterExpressionList $filterExpressionList) => $filterExpressionList
+                        ->not(fn (FilterExpression $filterExpression) => $filterExpression
+                            ->filter('browser', fn (Filter $filter) => $filter
+                                ->exact('Chrome')
+                            )
+                        )
+                        ->orGroup(fn (FilterExpressionList $filterExpressionList) => $filterExpressionList
+                            ->filter('browser', fn (Filter $filter) => $filter
+                                ->exact('Firefox')
+                            )
+                            ->filter('browser', fn (Filter $filter) => $filter
+                                ->exact('Safari')
+                            )
+                        )
+                    )
+                )
+            );
+
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+        $dimensionFilter = $requestData->dimensionFilter?->toRequest();
+
+        $this->assertNotNull($dimensionFilter);
+
+        $this->assertEquals([
+            'orGroup' => [
+                'expressions' => [
+                    [
+                        'andGroup' => [
+                            'expressions' => [
+                                [
+                                    'notExpression' => [
+                                        'filter' => [
+                                            'fieldName' => 'browser',
+                                            'stringFilter' => [
+                                                'matchType' => 'EXACT',
+                                                'value' => 'Chrome',
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                                [
+                                    'orGroup' => [
+                                        'expressions' => [
+                                            [
+                                                'filter' => [
+                                                    'fieldName' => 'browser',
+                                                    'stringFilter' => [
+                                                        'matchType' => 'EXACT',
+                                                        'value' => 'Firefox',
+                                                    ],
+                                                ],
+                                            ],
+                                            [
+                                                'filter' => [
+                                                    'fieldName' => 'browser',
+                                                    'stringFilter' => [
+                                                        'matchType' => 'EXACT',
+                                                        'value' => 'Safari',
+                                                    ],
+                                                ],
+                                            ],
+                                        ],
+                                    ],
+                                ],
+                            ],
+                        ],
+                    ],
+                ],
+            ],
+        ], json_decode($dimensionFilter->serializeToJsonString(), true));
     }
 }

--- a/tests/MetricsTest.php
+++ b/tests/MetricsTest.php
@@ -411,6 +411,7 @@ class MetricsTest extends TestCase
     /**
      * @param  Closure(Metrics): Metrics  $method
      * @param  string  $metric
+     *
      * @dataProvider metricProvider
      */
     public function test_predefined_metrics(Closure $method, string $metric): void


### PR DESCRIPTION
Resolves #48
Excerpt from `README`:

### <a name="filtering">Filtering:</a>

Filtering closely follows [Google Analytics Data API documentation](https://developers.google.com/analytics/devguides/reporting/data/v1/rest/v1beta/FilterExpression), but is built with a bit of convenience and fluid interface in mind. You can filter your query by using `dimensionFilter()` and `metricFilter()` methods. These methods accept a callback that receives an instance of `Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression` class. The class provides a set of methods to build your filter:

* `filter()` - generic filter method that accepts a dimension or metric name and a `filter callback`
* `filterDimension()` - filter method that accepts a dimension object via callback and a `filter callback`
* `filterMetric()` - filter method that accepts a metric object via callback and a `filter callback`
* `not()` - negates the filter
* `andGroup()` - creates a group of filters that are combined with AND operator
* `orGroup()` - creates a group of filters that are combined with OR operator

You can check `Gtmassey\LaravelAnalytics\Request\Filters\Filter` [class](https://github.com/gtmassey/laravel-analytics/tree/main/src/Request/Filters/Filter) for a list of available `filter callback` methods.

#### Examples:

##### `filter()` method:

```php
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
use Gtmassey\LaravelAnalytics\Request\Metrics;
use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\Period\Period;

$report = Analytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->pageTitle())
    ->forPeriod(Period::defaultPeriod())
    ->dimensionFilter(fn(FilterExpression $filterExpression) => $filterExpression
        ->filter('pageTitle', fn(Filter $filter) => $filter->exact('Home'))
    )
    ->run();
```

##### `filterDimension()` method:

Using this method you can utilize `Dimensions` class to fluently build your filter without having to know the exact dimension name that's used in the API.

```php
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
use Gtmassey\LaravelAnalytics\Request\Metrics;
use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\Period\Period;

$report = Analytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->pageTitle())
    ->forPeriod(Period::defaultPeriod())
    ->dimensionFilter(fn(FilterExpression $filterExpression) => $filterExpression
        ->filterDimension(
            dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->pageTitle(),
            filter: fn(Filter $filter) => $filter->exact('Home')
        )
    )
    ->run();
```

##### `filterMetric()` method:

Similar to `filterDimension()` method, you can use this method and utilize `Metrics` class to fluently build your filter without having to know the exact metric name that's used in the API.

```php
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
use Gtmassey\LaravelAnalytics\Request\Metrics;
use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\Period\Period;

$report = Analytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->pageTitle())
    ->forPeriod(Period::defaultPeriod())
    ->metricFilter(fn(FilterExpression $filterExpression) => $filterExpression
        ->filterMetric(
            metricsCallback: fn(Metrics $metrics) => $metrics->sessions(),
            filter: fn(Filter $filter) => $filter->greaterThanInt(100)
        )
    )
    ->run();
```

##### `not()` method:

```php
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
use Gtmassey\LaravelAnalytics\Request\Metrics;
use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\Period\Period;

$report = Analytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->pageTitle())
    ->forPeriod(Period::defaultPeriod())
    ->dimensionFilter(fn(FilterExpression $filterExpression) => $filterExpression
        ->not(fn(FilterExpression $filterExpression) => $filterExpression
            ->filter('pageTitle', fn(Filter $filter) => $filter
                 ->exact('Home')
            )
        )
    )
    ->run();
```

##### `andGroup()` method:

```php
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpressionList;
use Gtmassey\LaravelAnalytics\Request\Metrics;
use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\Period\Period;

$report = Analytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->deviceCategory()->browser())
    ->forPeriod(Period::defaultPeriod())
    ->dimensionFilter(fn(FilterExpression $filterExpression) => $filterExpression
        ->andGroup(fn(FilterExpressionList $filterExpressionList) => $filterExpressionList
            ->filter('deviceCategory', fn(Filter $filter) => $filter
                ->exact('Mobile')
			)
            ->filter('browser', fn(Filter $filter) => $filter
                ->exact('Chrome')
            )
        )
    )
    ->run();
```

##### `orGroup()` method:

```php
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpressionList;
use Gtmassey\LaravelAnalytics\Request\Metrics;
use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\Period\Period;

$report = Analytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->browser())
    ->forPeriod(Period::defaultPeriod())
    ->dimensionFilter(fn(FilterExpression $filterExpression) => $filterExpression
        ->orGroup(fn(FilterExpressionList $filterExpressionList) => $filterExpressionList
            ->filter('browser', fn(Filter $filter) => $filter
                ->exact('Firefox')
            )
            ->filter('browser', fn(Filter $filter) => $filter
                ->exact('Chrome')
            )
        )
    )
    ->run();
```

##### Advanced example:

You can mix all of the above methods to build a complex filter expression.

```php
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpressionList;
use Gtmassey\LaravelAnalytics\Request\Metrics;
use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\Period\Period;

$report = Analytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions()->screenPageViews())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->browser()->deviceCategory())
    ->forPeriod(Period::defaultPeriod())
    ->dimensionFilter(fn(FilterExpression $filterExpression) => $filterExpression
        ->andGroup(fn(FilterExpressionList $filterExpressionList) => $filterExpressionList
            ->filter('browser', fn(Filter $filter) => $filter
                ->contains('safari')
            )
            ->not(fn(FilterExpression $filterExpression) => $filterExpression
                ->filterDimension(
                    dimensionsCallback: fn(Dimensions $dimensions) => $dimensions->deviceCategory(),
                    filter: fn(Filter $filter) => $filter->contains('mobile')
                )
            )
        )
    )
    ->metricFilter(fn(FilterExpression $filterExpression) => $filterExpression
        ->orGroup(fn(FilterExpressionList $filterExpressionList) => $filterExpressionList
            ->filter('sessions', fn(Filter $filter) => $filter
                ->greaterThanInt(200)
            )
            ->filterMetric(
                metricsCallback: fn(Metrics $metrics) => $metrics->sessions(),
                filter: fn(Filter $filter) => $filter->lessThanInt(100)
            )
        )
    )
    ->run();
```

---

### <a name="reusablefilters">Reusable filters:</a>

You can create reusable filters to use in your queries. Create a new class that extends `Gtmassey\LaravelAnalytics\Analytics` and implement methods following this format:

```php
namespace App\Analytics;

use Gtmassey\LaravelAnalytics\Analytics;
use Gtmassey\LaravelAnalytics\Request\Filters\Filter;
use Gtmassey\LaravelAnalytics\Request\Filters\FilterExpression;
use Gtmassey\LaravelAnalytics\Request\Metrics;

class CustomAnalytics extends Analytics
{
    public function onlySessionsAbove(int $count): static
    {
        $this->metricFilter(fn(FilterExpression $filterExpression) => $filterExpression
            ->filterMetric(
                metricsCallback: fn(Metrics $metrics) => $metrics->sessions(),
                filter: fn(Filter $filter) => $filter->greaterThanInt($count),
            )
        );

        return $this;
    }
}
```

Bind the class in your `AppServiceProvider`:

```php
use Gtmassey\LaravelAnalytics\Analytics;
use App\Analytics\CustomAnalytics;

public function boot()
{
    $this->app->bind(Analytics::class, CustomAnalytics::class);
}
```

Now you can use the custom filter in your query:

```php
use App\Analytics\CustomAnalytics;
use Gtmassey\LaravelAnalytics\Period;
use Gtmassey\LaravelAnalytics\Request\Dimensions;
use Gtmassey\LaravelAnalytics\Request\Metrics;

$report = CustomAnalytics::query()
    ->setMetrics(fn(Metrics $metrics) => $metrics->sessions())
    ->setDimensions(fn(Dimensions $dimensions) => $dimensions->browser())
    ->forPeriod(Period::defaultPeriod())
    ->onlySessionsAbove(100)
    ->run();
```