### PR TITLE
Allow passing in `$popertyId` dynamically

### DIFF
--- a/.github/workflows/laravel-pint.yml
+++ b/.github/workflows/laravel-pint.yml
@@ -17,7 +17,9 @@ jobs:
           ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
-        uses: aglipanci/laravel-pint-action@1.0.0
+        uses: aglipanci/laravel-pint-action@2.0.0
+        with:
+          pintVersion: 1.6.0
 
       - name: Commit changes
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/.github/workflows/laravel-pint.yml
+++ b/.github/workflows/laravel-pint.yml
@@ -13,8 +13,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        with:
-          ref: ${{ github.head_ref }}
 
       - name: Fix PHP code style issues
         uses: aglipanci/laravel-pint-action@2.0.0

--- a/composer.json
+++ b/composer.json
@@ -25,15 +25,15 @@
         "spatie/laravel-package-tools": "^1.13"
     },
     "require-dev": {
-        "laravel/pint": "^1.2.1",
-        "nunomaduro/collision": "^6.3.1",
-        "nunomaduro/larastan": "^2.2.9",
-        "orchestra/testbench": "^7.15|^8.0",
+        "laravel/pint": "^1.6",
+        "nunomaduro/collision": "^6.4",
+        "nunomaduro/larastan": "^2.4.1",
+        "orchestra/testbench": "^7.15|^8.0.3",
         "phpstan/extension-installer": "^1.2",
-        "phpstan/phpstan-deprecation-rules": "^1.0",
-        "phpstan/phpstan-mockery": "^1.1",
-        "phpstan/phpstan-phpunit": "^1.2.2",
-        "phpunit/phpunit": "^9.5.26",
+        "phpstan/phpstan-deprecation-rules": "^1.1.2",
+        "phpstan/phpstan-mockery": "^1.1.1",
+        "phpstan/phpstan-phpunit": "^1.3.7",
+        "phpunit/phpunit": "^9.6.3",
         "rregeer/phpunit-coverage-check": "^0.3.1"
     },
     "autoload": {

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -38,7 +38,7 @@ class Analytics
         $this->requestData = new RequestData(propertyId: $propertyId);
     }
 
-    public static function query(?string $propertyId=null): static
+    public static function query(?string $propertyId = null): static
     {
         /** @var static $analytics */
         $analytics = resolve(Analytics::class, ['propertyId' => $propertyId]);

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -26,9 +26,11 @@ class Analytics
     /**
      * @throws InvalidPropertyIdException
      */
-    public function __construct()
+    public function __construct($propertyId = null)
     {
-        $propertyId = config('analytics.property_id');
+        if ($propertyId == null) {
+            $propertyId = config('analytics.property_id');
+        }
 
         if (! is_string($propertyId) || empty($propertyId)) {
             throw InvalidPropertyIdException::invalidPropertyId();
@@ -38,10 +40,10 @@ class Analytics
         $this->requestData = new RequestData(propertyId: $propertyId);
     }
 
-    public static function query(): static
+    public static function query($propertyId=null): static
     {
         /** @var static $analytics */
-        $analytics = resolve(Analytics::class);
+        $analytics = resolve(Analytics::class, ['propertyId' => $propertyId]);
 
         return $analytics;
     }

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -80,7 +80,6 @@ class Analytics
 
     /**
      * @param  Closure(FilterExpression): FilterExpression  $callback
-     * @return static
      */
     public function dimensionFilter(Closure $callback): static
     {
@@ -91,7 +90,6 @@ class Analytics
 
     /**
      * @param  Closure(FilterExpression): FilterExpression  $callback
-     * @return static
      */
     public function metricFilter(Closure $callback): static
     {

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -28,9 +28,7 @@ class Analytics
      */
     public function __construct(?string $propertyId = null)
     {
-        if ($propertyId == null) {
-            $propertyId = config('analytics.property_id');
-        }
+        $propertyId ??= config('analytics.property_id');
 
         if (! is_string($propertyId) || empty($propertyId)) {
             throw InvalidPropertyIdException::invalidPropertyId();

--- a/src/Analytics.php
+++ b/src/Analytics.php
@@ -26,7 +26,7 @@ class Analytics
     /**
      * @throws InvalidPropertyIdException
      */
-    public function __construct($propertyId = null)
+    public function __construct(?string $propertyId = null)
     {
         if ($propertyId == null) {
             $propertyId = config('analytics.property_id');
@@ -40,7 +40,7 @@ class Analytics
         $this->requestData = new RequestData(propertyId: $propertyId);
     }
 
-    public static function query($propertyId=null): static
+    public static function query(?string $propertyId=null): static
     {
         /** @var static $analytics */
         $analytics = resolve(Analytics::class, ['propertyId' => $propertyId]);

--- a/src/Request/Filters/AndGroup.php
+++ b/src/Request/Filters/AndGroup.php
@@ -11,7 +11,6 @@ class AndGroup implements FilterExpressionContract
 
     /**
      * @param  Closure(FilterExpressionList): FilterExpressionList  $expression
-     * @param  FilterExpressionField  $field
      */
     public function __construct(
         Closure $expression,

--- a/src/Request/Filters/FilterExpression.php
+++ b/src/Request/Filters/FilterExpression.php
@@ -14,7 +14,6 @@ class FilterExpression
 
     /**
      * @param  Closure(FilterExpressionList): FilterExpressionList  $filterExpressionList
-     * @return static
      */
     public function andGroup(Closure $filterExpressionList): static
     {
@@ -25,7 +24,6 @@ class FilterExpression
 
     /**
      * @param  Closure(FilterExpressionList): FilterExpressionList  $filterExpressionList
-     * @return static
      */
     public function orGroup(Closure $filterExpressionList): static
     {
@@ -36,7 +34,6 @@ class FilterExpression
 
     /**
      * @param  Closure(FilterExpression): FilterExpression  $filterExpression
-     * @return static
      */
     public function not(Closure $filterExpression): static
     {
@@ -46,9 +43,7 @@ class FilterExpression
     }
 
     /**
-     * @param  string  $dimension
      * @param  Closure(Filter): Filter  $filter
-     * @return static
      */
     public function filter(string $dimension, Closure $filter): static
     {
@@ -58,9 +53,7 @@ class FilterExpression
     }
 
     /**
-     * @param  Closure  $dimensionsCallback
      * @param  Closure(Filter): Filter  $filter
-     * @return static
      *
      * @throws InvalidFilterException
      */
@@ -79,9 +72,7 @@ class FilterExpression
     }
 
     /**
-     * @param  Closure  $metricsCallback
      * @param  Closure(Filter): Filter  $filter
-     * @return static
      *
      * @throws InvalidFilterException
      */

--- a/src/Request/Filters/FilterExpressionList.php
+++ b/src/Request/Filters/FilterExpressionList.php
@@ -17,7 +17,6 @@ class FilterExpressionList
 
     /**
      * @param  Closure(FilterExpressionList): FilterExpressionList  $filterExpressionList
-     * @return static
      */
     public function andGroup(Closure $filterExpressionList): static
     {
@@ -28,7 +27,6 @@ class FilterExpressionList
 
     /**
      * @param  Closure(FilterExpressionList): FilterExpressionList  $filterExpressionList
-     * @return static
      */
     public function orGroup(Closure $filterExpressionList): static
     {
@@ -39,7 +37,6 @@ class FilterExpressionList
 
     /**
      * @param  Closure(FilterExpression): FilterExpression  $filterExpression
-     * @return static
      */
     public function not(Closure $filterExpression): static
     {
@@ -49,9 +46,7 @@ class FilterExpressionList
     }
 
     /**
-     * @param  string  $dimension
      * @param  Closure(Filter): Filter  $filter
-     * @return static
      */
     public function filter(string $dimension, Closure $filter): static
     {
@@ -61,9 +56,7 @@ class FilterExpressionList
     }
 
     /**
-     * @param  Closure  $dimensionsCallback
      * @param  Closure(Filter): Filter  $filter
-     * @return static
      *
      * @throws InvalidFilterException
      */
@@ -75,9 +68,7 @@ class FilterExpressionList
     }
 
     /**
-     * @param  Closure  $metricsCallback
      * @param  Closure(Filter): Filter  $filter
-     * @return static
      *
      * @throws InvalidFilterException
      */

--- a/src/Request/Filters/NotExpression.php
+++ b/src/Request/Filters/NotExpression.php
@@ -11,7 +11,6 @@ class NotExpression implements FilterExpressionContract
 
     /**
      * @param  Closure(FilterExpression): FilterExpression  $expression
-     * @param  FilterExpressionField  $field
      */
     public function __construct(
         Closure $expression,

--- a/src/Request/Filters/OrGroup.php
+++ b/src/Request/Filters/OrGroup.php
@@ -11,7 +11,6 @@ class OrGroup implements FilterExpressionContract
 
     /**
      * @param  Closure(FilterExpressionList): FilterExpressionList  $expression
-     * @param  FilterExpressionField  $field
      */
     public function __construct(
         Closure $expression,

--- a/src/Response/ResponseData.php
+++ b/src/Response/ResponseData.php
@@ -14,10 +14,6 @@ class ResponseData extends Data
      * @param  DataCollection<int, MetricHeader>  $metricHeaders
      * @param  DataCollection<int, Row>  $rows
      * @param  DataCollection<int, Total>|null  $totals
-     * @param  int  $rowCount
-     * @param  Metadata  $metadata
-     * @param  PropertyQuota|null  $propertyQuota
-     * @param  string  $kind
      */
     public function __construct(
         #[DataCollectionOf(DimensionHeader::class)]

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -34,6 +34,18 @@ class AnalyticsTest extends TestCase
     {
         $this->assertInstanceOf(Analytics::class, new Analytics());
     }
+    public function test_constructor_with_propertyid(): void
+    {
+        config()->set('analytics.property_id', 'def');
+        $newPropertyId = 'abc';
+        $analytics = new Analytics($newPropertyId);
+        $this->assertInstanceOf(Analytics::class, $analytics);
+
+        /** @var RequestData $requestData */
+        $requestData = (new ReflectionProperty(Analytics::class, 'requestData'))->getValue($analytics);
+
+        $this->assertEquals($newPropertyId, $requestData->propertyId);
+    }
 
     public function test_property_string_is_empty_exception(): void
     {

--- a/tests/AnalyticsTest.php
+++ b/tests/AnalyticsTest.php
@@ -34,6 +34,7 @@ class AnalyticsTest extends TestCase
     {
         $this->assertInstanceOf(Analytics::class, new Analytics());
     }
+
     public function test_constructor_with_propertyid(): void
     {
         config()->set('analytics.property_id', 'def');

--- a/tests/DimensionsTest.php
+++ b/tests/DimensionsTest.php
@@ -915,7 +915,6 @@ class DimensionsTest extends TestCase
 
     /**
      * @param  Closure(Dimensions): Dimensions  $method
-     * @param  string  $dimension
      *
      * @dataProvider dimensionProvider
      */

--- a/tests/MetricsTest.php
+++ b/tests/MetricsTest.php
@@ -410,7 +410,6 @@ class MetricsTest extends TestCase
 
     /**
      * @param  Closure(Metrics): Metrics  $method
-     * @param  string  $metric
      *
      * @dataProvider metricProvider
      */


### PR DESCRIPTION
The optional parameter $propertyId allows bypassing the configured parameter. This allows adding properties via API then using them here. Useful for cross-domain tracking also.